### PR TITLE
chore(docs): update security reporting link from Twitter to X

### DIFF
--- a/security.md
+++ b/security.md
@@ -1,2 +1,2 @@
 ### Security Issues?
-Please report sensitive security issues via Twitter's bug-bounty program (https://hackerone.com/twitter) rather than GitHub.
+Please report sensitive security issues via X/Twitter's bug-bounty program (https://hackerone.com/x) rather than GitHub.


### PR DESCRIPTION
### Description

Updates the Security Issues section in the documentation to reflect the rebranding from Twitter to X.

### Changes
- Replaced references to Twitter’s bug bounty program with X/Twitter’s bug bounty program
- Updated the HackerOne URL from hackerone.com/twitter to hackerone.com/x

### Why

Ensures the documentation remains accurate and points to the correct security reporting channel for sensitive issues.